### PR TITLE
feat: externalIPs for services

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -3,6 +3,6 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: "0.46.0"
 icon: https://images.crunchbase.com/image/upload/c_pad,h_256,w_256,f_auto,q_auto:eco,dpr_1/kuu5tm1wt09ztp6ctlag

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | dashboard.service.name | string | `"http"` |  |
 | dashboard.service.port | int | `80` |  |
 | dashboard.service.type | string | `"ClusterIP"` |  |
+| dashboard.service.externalIPs | list | `[]` |  |
 | dashboard.serviceAccount.annotations | object | `{}` |  |
 | dashboard.serviceAccount.create | bool | `true` |  |
 | dashboard.serviceAccount.name | string | `""` |  |
@@ -152,12 +153,14 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | management.service.name | string | `"http"` |  |
 | management.service.port | int | `80` |  |
 | management.service.type | string | `"ClusterIP"` |  |
+| management.service.externalIPs | list | `[]` |  |
 | management.serviceAccount.annotations | object | `{}` |  |
 | management.serviceAccount.create | bool | `true` |  |
 | management.serviceAccount.name | string | `""` |  |
 | management.serviceGrpc.name | string | `"grpc"` |  |
 | management.serviceGrpc.port | int | `33073` |  |
 | management.serviceGrpc.type | string | `"ClusterIP"` |  |
+| management.serviceGrpc.externalIPs | list | `[]` |  |
 | management.tolerations | list | `[]` |  |
 | management.useBackwardsGrpcService | bool | `false` |  |
 | metrics.serviceMonitor.annotations | object | `{}` |  |
@@ -210,6 +213,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | relay.service.name | string | `"http"` |  |
 | relay.service.port | int | `33080` |  |
 | relay.service.type | string | `"ClusterIP"` |  |
+| relay.service.externalIPs | list | `[]` |  |
 | relay.serviceAccount.annotations | object | `{}` |  |
 | relay.serviceAccount.create | bool | `true` |  |
 | relay.serviceAccount.name | string | `""` |  |
@@ -249,6 +253,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | signal.service.name | string | `"grpc"` |  |
 | signal.service.port | int | `80` |  |
 | signal.service.type | string | `"ClusterIP"` |  |
+| signal.service.externalIPs | list | `[]` |  |
 | signal.serviceAccount.annotations | object | `{}` |  |
 | signal.serviceAccount.create | bool | `true` |  |
 | signal.serviceAccount.name | string | `""` |  |

--- a/charts/netbird/templates/dashboard-service.yaml
+++ b/charts/netbird/templates/dashboard-service.yaml
@@ -15,4 +15,8 @@ spec:
       name: http
   selector:
     {{- include "netbird.dashboard.selectorLabels" . | nindent 4 }}
+  {{- with .Values.dashboard.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird/templates/management-service-grpc.yaml
+++ b/charts/netbird/templates/management-service-grpc.yaml
@@ -15,4 +15,8 @@ spec:
       name: {{ .Values.management.serviceGrpc.name }}
   selector:
     {{- include "netbird.management.selectorLabels" . | nindent 4 }}
+  {{- with .Values.management.serviceGrpc.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird/templates/management-service.yaml
+++ b/charts/netbird/templates/management-service.yaml
@@ -21,4 +21,8 @@ spec:
     {{- end }}
   selector:
     {{- include "netbird.management.selectorLabels" . | nindent 4 }}
+  {{- with .Values.management.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird/templates/relay-service.yaml
+++ b/charts/netbird/templates/relay-service.yaml
@@ -18,7 +18,11 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
-    {{- end}}
+    {{- end }}
   selector:
     {{- include "netbird.relay.selectorLabels" . | nindent 4 }}
+  {{- with .Values.relay.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird/templates/signal-service.yaml
+++ b/charts/netbird/templates/signal-service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.signal.enabled -}}
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,5 +21,8 @@ spec:
     {{- end }}
   selector:
     {{- include "netbird.signal.selectorLabels" . | nindent 4 }}
-
+  {{- with .Values.signal.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -130,32 +130,38 @@ management:
     ##
     type: ClusterIP
 
-
     ## @param management.service.port Port for the management service.
     ##
     port: 80
 
-    ## @param management.service.name Name for the management service.
+    ## @param management.service.name Name for the management service port.
     ##
     name: http
+
+    ## @param management.service.externalIPs External IPs for the management service.
+    ##
+    externalIPs: []
 
   ## @param management.grpcContainerPort Container port for the management service.
   ##
   grpcContainerPort: 33073
 
   serviceGrpc:
-    ## @param management.serviceGrpc.type Service type for the management component.
+    ## @param management.serviceGrpc.type Service type for the management GRPC component.
     ##
     type: ClusterIP
 
-
-    ## @param management.serviceGrpc.port Port for the management service.
+    ## @param management.serviceGrpc.port Port for the management GRPC service.
     ##
     port: 33073
 
-    ## @param management.serviceGrpc.name Name for the management service.
+    ## @param management.serviceGrpc.name Name for the management GRPC service port.
     ##
     name: grpc
+
+    ## @param management.serviceGrpc.externalIPs External IPs for the management GRPC service.
+    ##
+    externalIPs: []
 
   ingress:
     ## @param management.ingress.enabled Enable or disable ingress for the management component.
@@ -361,6 +367,7 @@ signal:
     ## @param signal.metrics.enabled enables/disables metrics
     ##
     enabled: false
+
     ## @param signal.metrics.port target metrics port
     ##
     port: 9090
@@ -373,10 +380,18 @@ signal:
     ## @param signal.service.type Service type for the signal component.
     ##
     type: ClusterIP
-    name: grpc
+
     ## @param signal.service.port Port for the signal service.
     ##
     port: 80
+
+    ## @param signal.service.name Name for the signal service port.
+    ##
+    name: grpc
+
+    ## @param signal.service.externalIPs External IPs for the signal service.
+    ##
+    externalIPs: []
 
   ingress:
     ## @param signal.ingress.enabled Enable or disable ingress for the signal component.
@@ -555,14 +570,17 @@ relay:
     ##
     type: ClusterIP
 
-
     ## @param relay.service.port Port for the relay service.
     ##
     port: 33080
 
-    ## @param relay.service.name Name for the relay service.
+    ## @param relay.service.name Name for the relay service port.
     ##
     name: http
+
+    ## @param relay.service.externalIPs External IPs for the relay service.
+    ##
+    externalIPs: []
 
   ingress:
     ## @param relay.ingress.enabled Enable or disable ingress for the relay component.
@@ -709,15 +727,21 @@ dashboard:
   containerPort: 80
 
   service:
-    ## @param dashboard.service.type
+    ## @param dashboard.service.type Service type for the dashboard component.
+    ##
     type: ClusterIP
 
-
-    ## @param dashboard.service.port
+    ## @param dashboard.service.port Port for the dashboard service.
+    ##
     port: 80
 
-    ## @param dashboard.service.name
+    ## @param dashboard.service.name Name for the dashboard service port.
+    ##
     name: http
+
+    ## @param dashboard.service.externalIPs External IPs for the dashboard service.
+    ##
+    externalIPs: []
 
   ingress:
     ## @param dashboard.ingress.enabled


### PR DESCRIPTION
Possibility of adding external IPs for all services in the Netbird Helm chart.