### PR TITLE
fix[kubernetes-operator]: Wrong nindent for array values

### DIFF
--- a/charts/kubernetes-operator/templates/deployment.yaml
+++ b/charts/kubernetes-operator/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             name: webhook-certs
             readOnly: true
           {{- with .Values.operator.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
       volumes:
       - name: webhook-certs
@@ -118,7 +118,7 @@ spec:
           defaultMode: 420
           secretName: {{ template "kubernetes-operator.webhookCertSecret" . }}
       {{- with .Values.operator.volumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:
@@ -130,5 +130,5 @@ spec:
       {{- end }}
       {{- with .Values.operator.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Before this fix, I couldn't add volumes and volumesMount because of bad nindent
with actual values, volumes and ninent get to one more tab than other volumes and volumeMounts

## Before fix

**Error**
```
 Upgrade failed: YAML parse error on kubernetes-operator/templates/deployment.yaml: error converting YAML to JSON: yaml: line 91: did not find expected key
```

**Values**
```
operator:
  volumeMounts:
  - mountPath: "path"
    name:  "vol"
    readOnly: true
    subPath: "subpath"

  volumes:
  - name: "vol"
    configMap:
      defaultMode: 420
      name: "conf-name"
```