### PR TITLE
fix: increase default management PVC size to 100Mi

### DIFF
--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -132,7 +132,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | management.persistentVolume.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | management.persistentVolume.enabled | bool | `true` |  |
 | management.persistentVolume.existingPVName | string | `""` |  |
-| management.persistentVolume.size | string | `"10Mi"` |  |
+| management.persistentVolume.size | string | `"100Mi"` |  |
 | management.persistentVolume.storageClass | string | `nil` |  |
 | management.podAnnotations | object | `{}` |  |
 | management.podCommand.args[0] | string | `"--port=80"` |  |

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -266,7 +266,7 @@ management:
 
     ## @param management.persistentVolume.size Size of the persistent volume.
     ##
-    size: 10Mi
+    size: 100Mi
 
     ## @param management.persistentVolume.storageClass Storage Class of the persistent volume.
     ##


### PR DESCRIPTION
The management PVC stores the MaxMind GeoIP database and converts a subset of the information into a SQLite database.

These two files amount to roughly 66Mi, which never fit into the current default value of 10Mi.