### PR TITLE
fix(): set AUTH_AUDIENCE variable

### DIFF
--- a/charts/netbird/examples/istio/zitadel/values.yaml
+++ b/charts/netbird/examples/istio/zitadel/values.yaml
@@ -148,6 +148,7 @@ dashboard:
   envFromSecret:
     AUTH_CLIENT_ID: netbird/idpClientID
     AUTH_CLIENT_SECRET: netbird/idpClientSecret
+    AUTH_AUDIENCE: netbird/idpClientID
 extraManifests:
   - apiVersion: networking.istio.io/v1
     kind: VirtualService


### PR DESCRIPTION
Fix error in dasboard pod logs for missing variable 
"AUTH_AUDIENCE or AUTH0_AUDIENCE environment variable must be set" 

On the login page is - "There was an error logging you in. Error: Unauthenticated"