### PR TITLE
feat: add option to disable management datadir mount

### DIFF
--- a/charts/netbird/templates/management-deployment.yaml
+++ b/charts/netbird/templates/management-deployment.yaml
@@ -94,8 +94,10 @@ spec:
           volumeMounts:
             - mountPath: /etc/netbird
               name: config
+            {{- if .Values.management.mountDatadir }}
             - mountPath: /var/lib/netbird
               name: management
+            {{- end }}
           {{- if .Values.management.volumeMounts }}
           {{- .Values.management.volumeMounts | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -306,6 +306,9 @@ management:
   # - name: tmp
   #   emptyDir: {}
 
+  ## @param management.mountDatadir Enable or disable netbird datadir mount.
+  mountDatadir: true
+
 ## @section NetBird Signal
 
 signal:


### PR DESCRIPTION
In airgap environments, management fails if it cannot download the geolocation database. 
To support airgap setups, this change allows the /var/lib/netbird volume mount to be 
conditionally disabled via a Helm value. This lets users prepopulate the geolocation 
files directly in the management image without the mount overwriting them.

Closes #19