### PR TITLE
Add reverse proxy helm chart

### DIFF
--- a/charts/netbird-proxy/Chart.yaml
+++ b/charts/netbird-proxy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: netbird-proxy
+description: NetBird reverse proxy with ACME certificate management
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/netbird-proxy/templates/NOTES.txt
+++ b/charts/netbird-proxy/templates/NOTES.txt
@@ -30,3 +30,15 @@ ACME certificate management is enabled ({{ .Values.acme.directory }}).
 Certificates are stored in {{ .Values.certDir }}.
 Lock method: {{ .Values.acme.certLockMethod }}
 {{- end }}
+
+{{- if .Values.proxy.proxyProtocol }}
+
+PROXY protocol is enabled. Ensure your L4 load balancer sends
+PROXY protocol v1 or v2 headers.
+{{- if .Values.proxy.trustedProxies }}
+Trusted sources: {{ .Values.proxy.trustedProxies }}
+{{- else }}
+WARNING: No trustedProxies set. Any source can send PROXY headers.
+Set proxy.trustedProxies to your load balancer's CIDR for security.
+{{- end }}
+{{- end }}

--- a/charts/netbird-proxy/templates/NOTES.txt
+++ b/charts/netbird-proxy/templates/NOTES.txt
@@ -1,0 +1,32 @@
+NetBird Proxy has been deployed.
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+
+The proxy is exposed via a LoadBalancer service.
+It may take a few minutes for the external IP to be provisioned.
+
+  kubectl get svc {{ include "netbird-proxy.fullname" . }} -n {{ .Release.Namespace }} -w
+
+{{- else if eq .Values.service.type "NodePort" }}
+
+The proxy is exposed via NodePort.
+
+  export NODE_PORT=$(kubectl get svc {{ include "netbird-proxy.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+  echo "https://${NODE_IP}:${NODE_PORT}"
+
+{{- else }}
+
+The proxy is using a ClusterIP service. To access it from outside the cluster,
+configure an Ingress resource or use port-forwarding:
+
+  kubectl port-forward svc/{{ include "netbird-proxy.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+{{- end }}
+
+{{- if .Values.acme.enabled }}
+
+ACME certificate management is enabled ({{ .Values.acme.directory }}).
+Certificates are stored in {{ .Values.certDir }}.
+Lock method: {{ .Values.acme.certLockMethod }}
+{{- end }}

--- a/charts/netbird-proxy/templates/_helpers.tpl
+++ b/charts/netbird-proxy/templates/_helpers.tpl
@@ -1,0 +1,92 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "netbird-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "netbird-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "netbird-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "netbird-proxy.labels" -}}
+helm.sh/chart: {{ include "netbird-proxy.chart" . }}
+{{ include "netbird-proxy.selectorLabels" . }}
+app.kubernetes.io/component: proxy
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "netbird-proxy.selectorLabels" -}}
+app: {{ include "netbird-proxy.fullname" . }}
+app.kubernetes.io/name: {{ include "netbird-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "netbird-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "netbird-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret containing the proxy token.
+*/}}
+{{- define "netbird-proxy.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "netbird-proxy.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Extract the port number from an address string.
+Handles ":8443", "0.0.0.0:8443", and "[::1]:8443".
+*/}}
+{{- define "netbird-proxy.port" -}}
+{{- mustRegexFind "[0-9]+$" . -}}
+{{- end -}}
+
+{{/*
+Name of the Secret containing the OIDC client secret.
+*/}}
+{{- define "netbird-proxy.oidcSecretName" -}}
+{{- if .Values.oidc.existingOidcSecret }}
+{{- .Values.oidc.existingOidcSecret }}
+{{- else }}
+{{- printf "%s-oidc" (include "netbird-proxy.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -64,6 +64,11 @@ spec:
               containerPort: {{ include "netbird-proxy.port" .Values.debug.address | default 8444 }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.wireguard.enabled }}
+            - name: wireguard
+              containerPort: {{ .Values.wireguard.port }}
+              protocol: UDP
+            {{- end }}
           env:
             - name: USER
               value: "netbird"
@@ -135,6 +140,10 @@ spec:
             {{- if .Values.oidc.scopes }}
             - name: NB_PROXY_OIDC_SCOPES
               value: {{ .Values.oidc.scopes | quote }}
+            {{- end }}
+            {{- if .Values.wireguard.enabled }}
+            - name: NB_PROXY_WG_PORT
+              value: {{ .Values.wireguard.port | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: NB_PROXY_DEBUG_ENDPOINT

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -1,0 +1,227 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "netbird-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      # Shutdown budget: 5s pre-stop LB drain + 30s HTTPS drain + 5s service stop + 30s client stop + 5s buffer
+      terminationGracePeriodSeconds: 75
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "netbird-proxy.serviceAccountName" . }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: proxy
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: https
+              containerPort: {{ include "netbird-proxy.port" .Values.proxy.address | default 8443 }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ include "netbird-proxy.port" .Values.health.address | default 8080 }}
+              protocol: TCP
+            {{- if .Values.acme.enabled }}
+            - name: acme-http
+              containerPort: {{ include "netbird-proxy.port" .Values.acme.address | default 80 }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.debug.enabled }}
+            - name: debug
+              containerPort: {{ include "netbird-proxy.port" .Values.debug.address | default 8444 }}
+              protocol: TCP
+            {{- end }}
+          env:
+            - name: USER
+              value: "netbird"
+            - name: HOME
+              value: "/tmp"
+            - name: NB_PROXY_ADDRESS
+              value: {{ .Values.proxy.address | quote }}
+            - name: NB_PROXY_MANAGEMENT_ADDRESS
+              value: {{ .Values.managementAddress | quote }}
+            - name: NB_PROXY_HEALTH_ADDRESS
+              value: {{ .Values.health.address | quote }}
+            - name: NB_PROXY_CERTIFICATE_DIRECTORY
+              value: {{ .Values.certDir | quote }}
+            - name: NB_PROXY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "netbird-proxy.secretName" . }}
+                  key: token
+            {{- if .Values.allowInsecure }}
+            - name: NB_PROXY_ALLOW_INSECURE
+              value: "true"
+            {{- end }}
+            {{- if .Values.logging.debug }}
+            - name: NB_PROXY_DEBUG_LOGS
+              value: "true"
+            {{- end }}
+            {{- if .Values.proxy.url }}
+            - name: NB_PROXY_URL
+              value: {{ .Values.proxy.url | quote }}
+            {{- end }}
+            {{- if and .Values.proxy.forwardedProto (ne .Values.proxy.forwardedProto "auto") }}
+            - name: NB_PROXY_FORWARDED_PROTO
+              value: {{ .Values.proxy.forwardedProto | quote }}
+            {{- end }}
+            {{- if .Values.proxy.trustedProxies }}
+            - name: NB_PROXY_TRUSTED_PROXIES
+              value: {{ .Values.proxy.trustedProxies | quote }}
+            {{- end }}
+            {{- if .Values.acme.enabled }}
+            - name: NB_PROXY_ACME_CERTIFICATES
+              value: "true"
+            - name: NB_PROXY_ACME_ADDRESS
+              value: {{ .Values.acme.address | quote }}
+            - name: NB_PROXY_ACME_DIRECTORY
+              value: {{ .Values.acme.directory | quote }}
+            - name: NB_PROXY_CERT_LOCK_METHOD
+              value: {{ .Values.acme.certLockMethod | quote }}
+            {{- else }}
+            - name: NB_PROXY_CERTIFICATE_FILE
+              value: {{ .Values.tls.certFile | quote }}
+            - name: NB_PROXY_CERTIFICATE_KEY_FILE
+              value: {{ .Values.tls.keyFile | quote }}
+            {{- end }}
+            {{- if .Values.oidc.clientId }}
+            - name: NB_PROXY_OIDC_CLIENT_ID
+              value: {{ .Values.oidc.clientId | quote }}
+            {{- end }}
+            {{- if or .Values.oidc.clientSecret .Values.oidc.existingOidcSecret }}
+            - name: NB_PROXY_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "netbird-proxy.oidcSecretName" . }}
+                  key: oidc-client-secret
+            {{- end }}
+            {{- if .Values.oidc.endpoint }}
+            - name: NB_PROXY_OIDC_ENDPOINT
+              value: {{ .Values.oidc.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.oidc.scopes }}
+            - name: NB_PROXY_OIDC_SCOPES
+              value: {{ .Values.oidc.scopes | quote }}
+            {{- end }}
+            {{- if .Values.debug.enabled }}
+            - name: NB_PROXY_DEBUG_ENDPOINT
+              value: "true"
+            - name: NB_PROXY_DEBUG_ENDPOINT_ADDRESS
+              value: {{ .Values.debug.address | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: certs
+              mountPath: {{ .Values.certDir }}
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz/live
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz/startup
+              port: health
+            periodSeconds: 2
+            timeoutSeconds: 10
+            # 60 * 2s = 120s for ACME certs + management sync + client startup
+            failureThreshold: 60
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: certs
+          {{- if .Values.certVolume.hostPath }}
+          hostPath:
+            path: {{ .Values.certVolume.hostPath }}
+            type: DirectoryOrCreate
+          {{- else if .Values.certVolume.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.certVolume.existingClaim }}
+          {{- else if .Values.certVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "netbird-proxy.fullname" . }}-certs
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if not .Values.affinity }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "netbird-proxy.selectorLabels" . | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+      {{- else }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
             - name: NB_PROXY_TRUSTED_PROXIES
               value: {{ .Values.proxy.trustedProxies | quote }}
             {{- end }}
+            {{- if .Values.proxy.proxyProtocol }}
+            - name: NB_PROXY_PROXY_PROTOCOL
+              value: "true"
+            {{- end }}
             {{- if .Values.acme.enabled }}
             - name: NB_PROXY_ACME_CERTIFICATES
               value: "true"

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -95,9 +95,9 @@ spec:
             - name: NB_PROXY_DEBUG_LOGS
               value: "true"
             {{- end }}
-            {{- if .Values.proxy.url }}
-            - name: NB_PROXY_URL
-              value: {{ .Values.proxy.url | quote }}
+            {{- if .Values.proxy.domain }}
+            - name: NB_PROXY_DOMAIN
+              value: {{ .Values.proxy.domain | quote }}
             {{- end }}
             {{- if and .Values.proxy.forwardedProto (ne .Values.proxy.forwardedProto "auto") }}
             - name: NB_PROXY_FORWARDED_PROTO

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -184,10 +184,8 @@ spec:
             - name: NB_PROXY_WG_PORT
               value: {{ .Values.netbirdPort.port | quote }}
             {{- end }}
-            {{- if .Values.supportsCustomPorts }}
             - name: NB_PROXY_SUPPORTS_CUSTOM_PORTS
-              value: "true"
-            {{- end }}
+              value: {{ .Values.supportsCustomPorts | quote }}
             {{- if .Values.requireSubdomain }}
             - name: NB_PROXY_REQUIRE_SUBDOMAIN
               value: "true"

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.initContainers }}
@@ -64,10 +68,15 @@ spec:
               containerPort: {{ include "netbird-proxy.port" .Values.debug.address | default 8444 }}
               protocol: TCP
             {{- end }}
-            {{- if .Values.wireguard.enabled }}
-            - name: wireguard
-              containerPort: {{ .Values.wireguard.port }}
+            {{- if .Values.netbirdPort.enabled }}
+            - name: netbird
+              containerPort: {{ .Values.netbirdPort.port }}
               protocol: UDP
+            {{- end }}
+            {{- range .Values.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol }}
             {{- end }}
           env:
             - name: USER
@@ -114,10 +123,20 @@ spec:
             {{- if .Values.acme.enabled }}
             - name: NB_PROXY_ACME_CERTIFICATES
               value: "true"
+            - name: NB_PROXY_ACME_CHALLENGE_TYPE
+              value: {{ .Values.acme.challengeType | quote }}
             - name: NB_PROXY_ACME_ADDRESS
               value: {{ .Values.acme.address | quote }}
             - name: NB_PROXY_ACME_DIRECTORY
               value: {{ .Values.acme.directory | quote }}
+            {{- if .Values.acme.eabKid }}
+            - name: NB_PROXY_ACME_EAB_KID
+              value: {{ .Values.acme.eabKid | quote }}
+            {{- end }}
+            {{- if .Values.acme.eabHmacKey }}
+            - name: NB_PROXY_ACME_EAB_HMAC_KEY
+              value: {{ .Values.acme.eabHmacKey | quote }}
+            {{- end }}
             - name: NB_PROXY_CERT_LOCK_METHOD
               value: {{ .Values.acme.certLockMethod | quote }}
             {{- else }}
@@ -145,9 +164,24 @@ spec:
             - name: NB_PROXY_OIDC_SCOPES
               value: {{ .Values.oidc.scopes | quote }}
             {{- end }}
-            {{- if .Values.wireguard.enabled }}
+            {{- if .Values.netbirdPort.enabled }}
             - name: NB_PROXY_WG_PORT
-              value: {{ .Values.wireguard.port | quote }}
+              value: {{ .Values.netbirdPort.port | quote }}
+            {{- end }}
+            {{- if .Values.supportsCustomPorts }}
+            - name: NB_PROXY_SUPPORTS_CUSTOM_PORTS
+              value: "true"
+            {{- end }}
+            {{- if .Values.requireSubdomain }}
+            - name: NB_PROXY_REQUIRE_SUBDOMAIN
+              value: "true"
+            {{- end }}
+            {{- if .Values.geolocation.enabled }}
+            - name: NB_PROXY_GEO_DATA_DIR
+              value: {{ .Values.geolocation.dataDir | quote }}
+            {{- else }}
+            - name: NB_PROXY_DISABLE_GEOLOCATION
+              value: "true"
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: NB_PROXY_DEBUG_ENDPOINT
@@ -163,6 +197,8 @@ spec:
               mountPath: {{ .Values.certDir }}
             - name: tmp
               mountPath: /tmp
+            - name: data
+              mountPath: /var/lib/netbird
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -209,6 +245,16 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
+        - name: data
+          {{- if and .Values.geolocation.enabled .Values.geolocation.volume.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.geolocation.volume.existingClaim }}
+          {{- else if and .Values.geolocation.enabled .Values.geolocation.volume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "netbird-proxy.fullname" . }}-geodata
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -100,9 +100,9 @@ spec:
             - name: NB_PROXY_ALLOW_INSECURE
               value: "true"
             {{- end }}
-            {{- if .Values.logging.debug }}
-            - name: NB_PROXY_DEBUG_LOGS
-              value: "true"
+            {{- if and .Values.logging.level (ne .Values.logging.level "info") }}
+            - name: NB_PROXY_LOG_LEVEL
+              value: {{ .Values.logging.level | quote }}
             {{- end }}
             {{- if .Values.proxy.domain }}
             - name: NB_PROXY_DOMAIN
@@ -119,6 +119,18 @@ spec:
             {{- if .Values.proxy.proxyProtocol }}
             - name: NB_PROXY_PROXY_PROTOCOL
               value: "true"
+            {{- end }}
+            {{- if .Values.proxy.maxDialTimeout }}
+            - name: NB_PROXY_MAX_DIAL_TIMEOUT
+              value: {{ .Values.proxy.maxDialTimeout | quote }}
+            {{- end }}
+            {{- if .Values.proxy.maxSessionIdleTimeout }}
+            - name: NB_PROXY_MAX_SESSION_IDLE_TIMEOUT
+              value: {{ .Values.proxy.maxSessionIdleTimeout | quote }}
+            {{- end }}
+            {{- if .Values.preSharedKey }}
+            - name: NB_PROXY_PRESHARED_KEY
+              value: {{ .Values.preSharedKey | quote }}
             {{- end }}
             {{- if .Values.acme.enabled }}
             - name: NB_PROXY_ACME_CERTIFICATES
@@ -139,6 +151,10 @@ spec:
             {{- end }}
             - name: NB_PROXY_CERT_LOCK_METHOD
               value: {{ .Values.acme.certLockMethod | quote }}
+            {{- if .Values.acme.wildcardCertDir }}
+            - name: NB_PROXY_WILDCARD_CERT_DIR
+              value: {{ .Values.acme.wildcardCertDir | quote }}
+            {{- end }}
             {{- else }}
             - name: NB_PROXY_CERTIFICATE_FILE
               value: {{ .Values.tls.certFile | quote }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -203,6 +203,17 @@ spec:
             - name: NB_PROXY_DEBUG_ENDPOINT_ADDRESS
               value: {{ .Values.debug.address | quote }}
             {{- end }}
+            {{- if .Values.crowdsec.apiUrl }}
+            - name: NB_PROXY_CROWDSEC_API_URL
+              value: {{ .Values.crowdsec.apiUrl | quote }}
+            {{- end }}
+            {{- if or .Values.crowdsec.apiKey .Values.crowdsec.existingSecret }}
+            - name: NB_PROXY_CROWDSEC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.crowdsec.existingSecret | default (include "netbird-proxy.fullname" .) }}
+                  key: crowdsec-api-key
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: health
               containerPort: {{ include "netbird-proxy.port" .Values.health.address | default 8080 }}
               protocol: TCP
-            {{- if .Values.acme.enabled }}
+            {{- if and .Values.acme.enabled (eq .Values.acme.challengeType "http-01") }}
             - name: acme-http
               containerPort: {{ include "netbird-proxy.port" .Values.acme.address | default 80 }}
               protocol: TCP
@@ -262,6 +262,9 @@ spec:
           {{- else if .Values.certVolume.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .Values.certVolume.existingClaim }}
+          {{- else if .Values.certVolume.existingSecret }}
+          secret:
+            secretName: {{ .Values.certVolume.existingSecret }}
           {{- else if .Values.certVolume.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "netbird-proxy.fullname" . }}-certs

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -216,6 +216,18 @@ spec:
                   name: {{ .Values.crowdsec.existingSecret | default (include "netbird-proxy.fullname" .) }}
                   key: crowdsec-api-key
             {{- end }}
+            {{- if .Values.crowdsec.appsecUrl }}
+            - name: NB_PROXY_CROWDSEC_APPSEC_URL
+              value: {{ .Values.crowdsec.appsecUrl | quote }}
+            {{- end }}
+            {{- if .Values.crowdsec.appsecTimeout }}
+            - name: NB_PROXY_CROWDSEC_APPSEC_TIMEOUT
+              value: {{ .Values.crowdsec.appsecTimeout | quote }}
+            {{- end }}
+            {{- if .Values.crowdsec.appsecMaxBodyBytes }}
+            - name: NB_PROXY_CROWDSEC_APPSEC_MAX_BODY_BYTES
+              value: {{ .Values.crowdsec.appsecMaxBodyBytes | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -128,6 +128,8 @@ spec:
             - name: NB_PROXY_MAX_SESSION_IDLE_TIMEOUT
               value: {{ .Values.proxy.maxSessionIdleTimeout | quote }}
             {{- end }}
+            - name: NB_PROXY_ROSENPASS
+              value: {{ .Values.proxy.rosenpass | quote }}
             {{- if .Values.preSharedKey }}
             - name: NB_PROXY_PRESHARED_KEY
               value: {{ .Values.preSharedKey | quote }}

--- a/charts/netbird-proxy/templates/hpa.yaml
+++ b/charts/netbird-proxy/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "netbird-proxy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/netbird-proxy/templates/hpa.yaml
+++ b/charts/netbird-proxy/templates/hpa.yaml
@@ -12,6 +12,7 @@ spec:
     name: {{ include "netbird-proxy.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -29,4 +30,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/netbird-proxy/templates/networkpolicy.yaml
+++ b/charts/netbird-proxy/templates/networkpolicy.yaml
@@ -25,6 +25,10 @@ spec:
         - port: debug
           protocol: TCP
         {{- end }}
+        {{- if .Values.wireguard.enabled }}
+        - port: wireguard
+          protocol: UDP
+        {{- end }}
     {{- with .Values.networkPolicy.additionalIngress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/netbird-proxy/templates/networkpolicy.yaml
+++ b/charts/netbird-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: https
+          protocol: TCP
+        {{- if .Values.acme.enabled }}
+        - port: acme-http
+          protocol: TCP
+        {{- end }}
+        - port: health
+          protocol: TCP
+        {{- if .Values.debug.enabled }}
+        - port: debug
+          protocol: TCP
+        {{- end }}
+    {{- with .Values.networkPolicy.additionalIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/netbird-proxy/templates/networkpolicy.yaml
+++ b/charts/netbird-proxy/templates/networkpolicy.yaml
@@ -25,8 +25,8 @@ spec:
         - port: debug
           protocol: TCP
         {{- end }}
-        {{- if .Values.wireguard.enabled }}
-        - port: wireguard
+        {{- if .Values.netbirdPort.enabled }}
+        - port: netbird
           protocol: UDP
         {{- end }}
     {{- with .Values.networkPolicy.additionalIngress }}

--- a/charts/netbird-proxy/templates/networkpolicy.yaml
+++ b/charts/netbird-proxy/templates/networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
     - ports:
         - port: https
           protocol: TCP
-        {{- if .Values.acme.enabled }}
+        {{- if and .Values.acme.enabled (eq .Values.acme.challengeType "http-01") }}
         - port: acme-http
           protocol: TCP
         {{- end }}

--- a/charts/netbird-proxy/templates/pdb.yaml
+++ b/charts/netbird-proxy/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/netbird-proxy/templates/pdb.yaml
+++ b/charts/netbird-proxy/templates/pdb.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable)) }}
+{{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,10 +12,10 @@ spec:
   selector:
     matchLabels:
       {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/charts/netbird-proxy/templates/pvc.yaml
+++ b/charts/netbird-proxy/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.certVolume.enabled (not .Values.certVolume.existingClaim) (not .Values.certVolume.hostPath) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}-certs
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.certVolume.accessMode | default "ReadWriteMany" }}
+  {{- if .Values.certVolume.storageClass }}
+  storageClassName: {{ .Values.certVolume.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.certVolume.size | default "256Mi" }}
+{{- end }}

--- a/charts/netbird-proxy/templates/pvc.yaml
+++ b/charts/netbird-proxy/templates/pvc.yaml
@@ -15,3 +15,21 @@ spec:
     requests:
       storage: {{ .Values.certVolume.size | default "256Mi" }}
 {{- end }}
+---
+{{- if and .Values.geolocation.enabled .Values.geolocation.volume.enabled (not .Values.geolocation.volume.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}-geodata
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.geolocation.volume.accessMode | default "ReadWriteMany" }}
+  {{- if .Values.geolocation.volume.storageClass }}
+  storageClassName: {{ .Values.geolocation.volume.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.geolocation.volume.size | default "128Mi" }}
+{{- end }}

--- a/charts/netbird-proxy/templates/pvc.yaml
+++ b/charts/netbird-proxy/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certVolume.enabled (not .Values.certVolume.existingClaim) (not .Values.certVolume.hostPath) }}
+{{- if and .Values.certVolume.enabled (not .Values.certVolume.existingClaim) (not .Values.certVolume.existingSecret) (not .Values.certVolume.hostPath) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/netbird-proxy/templates/pvc.yaml
+++ b/charts/netbird-proxy/templates/pvc.yaml
@@ -9,7 +9,7 @@ spec:
   accessModes:
     - {{ .Values.certVolume.accessMode | default "ReadWriteMany" }}
   {{- if .Values.certVolume.storageClass }}
-  storageClassName: {{ .Values.certVolume.storageClass }}
+  storageClassName: {{ .Values.certVolume.storageClass | quote }}
   {{- end }}
   resources:
     requests:
@@ -27,7 +27,7 @@ spec:
   accessModes:
     - {{ .Values.geolocation.volume.accessMode | default "ReadWriteMany" }}
   {{- if .Values.geolocation.volume.storageClass }}
-  storageClassName: {{ .Values.geolocation.volume.storageClass }}
+  storageClassName: {{ .Values.geolocation.volume.storageClass | quote }}
   {{- end }}
   resources:
     requests:

--- a/charts/netbird-proxy/templates/role.yaml
+++ b/charts/netbird-proxy/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.rbac.create .Values.serviceAccount.create (eq .Values.acme.certLockMethod "k8s-lease") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+{{- end }}

--- a/charts/netbird-proxy/templates/role.yaml
+++ b/charts/netbird-proxy/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.serviceAccount.create (eq .Values.acme.certLockMethod "k8s-lease") }}
+{{- if and .Values.rbac.create (eq .Values.acme.certLockMethod "k8s-lease") (or .Values.serviceAccount.create .Values.serviceAccount.name) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/netbird-proxy/templates/rolebinding.yaml
+++ b/charts/netbird-proxy/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.serviceAccount.create (eq .Values.acme.certLockMethod "k8s-lease") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "netbird-proxy.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "netbird-proxy.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/netbird-proxy/templates/rolebinding.yaml
+++ b/charts/netbird-proxy/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.serviceAccount.create (eq .Values.acme.certLockMethod "k8s-lease") }}
+{{- if and .Values.rbac.create (eq .Values.acme.certLockMethod "k8s-lease") (or .Values.serviceAccount.create .Values.serviceAccount.name) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/netbird-proxy/templates/secret.yaml
+++ b/charts/netbird-proxy/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ .Values.proxyToken | b64enc | quote }}
+{{- end }}
+---
+{{- if and .Values.oidc.clientSecret (not .Values.oidc.existingOidcSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netbird-proxy.oidcSecretName" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  oidc-client-secret: {{ .Values.oidc.clientSecret | b64enc | quote }}
+{{- end }}

--- a/charts/netbird-proxy/templates/secret.yaml
+++ b/charts/netbird-proxy/templates/secret.yaml
@@ -8,6 +8,9 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.proxyToken | b64enc | quote }}
+  {{- if and .Values.crowdsec.apiKey (not .Values.crowdsec.existingSecret) }}
+  crowdsec-api-key: {{ .Values.crowdsec.apiKey | b64enc | quote }}
+  {{- end }}
 {{- end }}
 ---
 {{- if and .Values.oidc.clientSecret (not .Values.oidc.existingOidcSecret) }}

--- a/charts/netbird-proxy/templates/secret.yaml
+++ b/charts/netbird-proxy/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "netbird-proxy.labels" . | nindent 4 }}
 type: Opaque
 data:
-  token: {{ .Values.proxyToken | b64enc | quote }}
+  token: {{ required "proxyToken must be set when existingSecret is not provided" .Values.proxyToken | b64enc | quote }}
   {{- if and .Values.crowdsec.apiKey (not .Values.crowdsec.existingSecret) }}
   crowdsec-api-key: {{ .Values.crowdsec.apiKey | b64enc | quote }}
   {{- end }}

--- a/charts/netbird-proxy/templates/service.yaml
+++ b/charts/netbird-proxy/templates/service.yaml
@@ -43,3 +43,9 @@ spec:
       targetPort: debug
       protocol: TCP
     {{- end }}
+    {{- if .Values.wireguard.enabled }}
+    - name: wireguard
+      port: {{ .Values.wireguard.port }}
+      targetPort: wireguard
+      protocol: UDP
+    {{- end }}

--- a/charts/netbird-proxy/templates/service.yaml
+++ b/charts/netbird-proxy/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancer.ip }}
+  loadBalancerIP: {{ .Values.service.loadBalancer.ip }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancer.sourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancer.sourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancer.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.loadBalancer.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    {{- include "netbird-proxy.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+    {{- if .Values.acme.enabled }}
+    - name: acme-http
+      port: {{ .Values.service.acmePort }}
+      targetPort: acme-http
+      protocol: TCP
+    {{- end }}
+    - name: health
+      port: {{ include "netbird-proxy.port" .Values.health.address | default 8080 }}
+      targetPort: health
+      protocol: TCP
+    {{- if .Values.debug.enabled }}
+    - name: debug
+      port: {{ include "netbird-proxy.port" .Values.debug.address | default 8444 }}
+      targetPort: debug
+      protocol: TCP
+    {{- end }}

--- a/charts/netbird-proxy/templates/service.yaml
+++ b/charts/netbird-proxy/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancer.ip }}
   loadBalancerIP: {{ .Values.service.loadBalancer.ip }}
   {{- end }}

--- a/charts/netbird-proxy/templates/service.yaml
+++ b/charts/netbird-proxy/templates/service.yaml
@@ -50,9 +50,15 @@ spec:
       targetPort: debug
       protocol: TCP
     {{- end }}
-    {{- if .Values.wireguard.enabled }}
-    - name: wireguard
-      port: {{ .Values.wireguard.port }}
-      targetPort: wireguard
+    {{- if .Values.netbirdPort.enabled }}
+    - name: netbird
+      port: {{ .Values.netbirdPort.port }}
+      targetPort: netbird
       protocol: UDP
+    {{- end }}
+    {{- range .Values.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: {{ .protocol }}
     {{- end }}

--- a/charts/netbird-proxy/templates/service.yaml
+++ b/charts/netbird-proxy/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: https
       protocol: TCP
-    {{- if .Values.acme.enabled }}
+    {{- if and .Values.acme.enabled (eq .Values.acme.challengeType "http-01") }}
     - name: acme-http
       port: {{ .Values.service.acmePort }}
       targetPort: acme-http

--- a/charts/netbird-proxy/templates/serviceaccount.yaml
+++ b/charts/netbird-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "netbird-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}
+{{- end }}

--- a/charts/netbird-proxy/templates/servicemonitor.yaml
+++ b/charts/netbird-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "netbird-proxy.fullname" . }}
+  labels:
+    {{- include "netbird-proxy.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: health
+      path: {{ .Values.serviceMonitor.path }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  {{- with .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -32,6 +32,10 @@ proxy:
   forwardedProto: "auto"
   # -- Comma-separated CIDR ranges of trusted upstream proxies.
   trustedProxies: ""
+  # -- Enable PROXY protocol (v1/v2) on TCP listeners.
+  # Required when behind L4 proxies that support PROXY protocol.
+  # that use PROXY protocol to forward real client IPs.
+  proxyProtocol: false
 
 wireguard:
   # -- Enable WireGuard UDP port exposure for P2P connectivity.

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -1,0 +1,235 @@
+replicaCount: 2
+
+image:
+  repository: netbird-proxy
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Proxy token for management server authentication.
+# Ignored if existingSecret is set.
+proxyToken: ""
+
+# -- Use an existing Secret for the proxy token.
+# The secret must contain a key named "token".
+existingSecret: ""
+
+managementAddress: "https://api.netbird.io:443"
+
+# -- Allow proxy token over non-TLS management connections.
+allowInsecure: false
+
+proxy:
+  # -- Listen address for the HTTPS reverse proxy.
+  address: ":8443"
+  # -- Public URL of the proxy (used for ACME and client access).
+  # Leave empty to auto-derive from the proxy address.
+  url: ""
+  # -- X-Forwarded-Proto behaviour: auto, http, or https.
+  forwardedProto: "auto"
+  # -- Comma-separated CIDR ranges of trusted upstream proxies.
+  trustedProxies: ""
+
+acme:
+  # -- Enable ACME certificate generation.
+  enabled: true
+  # -- HTTP-01 challenge listen address.
+  address: ":80"
+  # -- ACME directory URL.
+  directory: "https://acme-v02.api.letsencrypt.org/directory"
+  # -- Certificate lock method: auto, flock, or k8s-lease.
+  certLockMethod: "k8s-lease"
+
+# -- Static TLS certificate configuration (used when acme.enabled=false).
+tls:
+  certFile: "tls.crt"
+  keyFile: "tls.key"
+
+oidc:
+  clientId: "netbird-proxy"
+  # -- OIDC client secret. Ignored if existingOidcSecret is set.
+  # For production, consider using existingOidcSecret with sealed-secrets
+  # or external-secrets-operator instead of storing the secret in values.
+  clientSecret: ""
+  # -- Use an existing Secret for the OIDC client secret.
+  # The secret must contain a key named "oidc-client-secret".
+  existingOidcSecret: ""
+  endpoint: "https://api.netbird.io/oauth2"
+  scopes: "openid,profile,email"
+
+debug:
+  # -- Enable the debug HTTP endpoint.
+  enabled: false
+  # -- Debug endpoint listen address.
+  address: ":8444"
+
+health:
+  # -- Health probe listen address.
+  address: ":8080"
+
+logging:
+  # -- Enable debug-level logging.
+  debug: false
+
+# -- Directory where certificates are stored inside the container.
+certDir: "/certs"
+
+# -- Certificate volume configuration.
+# ACME mode with multiple replicas requires a shared volume (RWX) because autocert
+# uses a DirCache and HTTP-01 challenges can arrive on any pod.
+# Set enabled=true to auto-provision a PVC, or supply an existingClaim.
+# For a single replica, emptyDir works but certs are lost on restart.
+certVolume:
+  # -- Enable persistent certificate storage via PVC.
+  # Defaults to true when acme is enabled; override to false for single-replica emptyDir.
+  enabled: true
+  # -- Mount an existing PVC instead of creating one.
+  existingClaim: ""
+  # -- Use a hostPath volume instead of a PVC.
+  # Takes precedence over enabled and existingClaim.
+  hostPath: ""
+  # -- PVC access mode. ReadWriteMany is required for multi-replica ACME
+  # (HTTP-01 challenges can arrive on any pod). ReadWriteOnce is fine for
+  # a single replica. Note: changing this on an existing release requires
+  # deleting and recreating the PVC (access modes are immutable).
+  accessMode: "ReadWriteMany"
+  # -- Storage class. Leave empty for the cluster default.
+  storageClass: ""
+  # -- PVC size.
+  size: "256Mi"
+
+serviceAccount:
+  # -- Create a ServiceAccount.
+  create: true
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+  # -- Override the ServiceAccount name.
+  name: ""
+  # -- Automount the ServiceAccount token. Required when using k8s-lease cert locking.
+  # Set to false if ACME is disabled or certLockMethod is not k8s-lease.
+  automount: true
+
+rbac:
+  # -- Create RBAC resources for k8s-lease cert locking.
+  create: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  # -- Service type: ClusterIP, LoadBalancer, or NodePort.
+  type: ClusterIP
+  # -- Annotations for the Service (e.g. cloud LB annotations).
+  annotations: {}
+  # -- HTTPS proxy port.
+  port: 443
+  # -- ACME HTTP-01 challenge port (only exposed if acme.enabled).
+  acmePort: 80
+
+  loadBalancer:
+    # -- Source ranges allowed to reach the LoadBalancer.
+    sourceRanges: []
+    # -- Request a specific LoadBalancer IP.
+    ip: ""
+    # -- External traffic policy: Cluster or Local.
+    # Local preserves client source IP but may cause imbalanced traffic.
+    externalTrafficPolicy: ""
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# -- Host aliases to inject into /etc/hosts.
+hostAliases: []
+#  - ip: "192.168.100.1"
+#    hostnames:
+#      - "host.docker.internal"
+
+# -- Pod topology spread constraints.
+topologySpreadConstraints: []
+
+# -- Node selector.
+nodeSelector: {}
+
+# -- Tolerations.
+tolerations: []
+
+# -- Affinity overrides. When empty, a default pod anti-affinity
+# (preferredDuringSchedulingIgnoredDuringExecution on hostname) is applied.
+affinity: {}
+
+podDisruptionBudget:
+  # -- Create a PodDisruptionBudget.
+  enabled: true
+  # -- Minimum available pods.
+  minAvailable: 1
+  # -- Maximum unavailable pods (mutually exclusive with minAvailable).
+  # maxUnavailable: 1
+
+serviceMonitor:
+  # -- Create a Prometheus ServiceMonitor resource.
+  enabled: false
+  # -- Extra labels for ServiceMonitor selector matching.
+  labels: {}
+  # -- Annotations on the ServiceMonitor.
+  annotations: {}
+  # -- Metrics endpoint path.
+  path: /metrics
+  # -- Scrape interval (e.g. "30s"). Uses Prometheus default if empty.
+  interval: ""
+  # -- Scrape timeout (e.g. "10s"). Uses Prometheus default if empty.
+  scrapeTimeout: ""
+  # -- Namespace selector for cross-namespace monitoring.
+  namespaceSelector: {}
+
+networkPolicy:
+  # -- Create a NetworkPolicy restricting ingress to proxy ports.
+  enabled: false
+  # -- Additional ingress rules to append.
+  additionalIngress: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# -- Extra environment variables to add to the proxy container.
+extraEnv: []
+#  - name: SSL_CERT_FILE
+#    value: "/pebble-ca/pebble-ca.pem"
+
+# -- Extra volumes to add to the pod.
+extraVolumes: []
+#  - name: pebble-ca
+#    secret:
+#      secretName: pebble-ca
+
+# -- Extra volume mounts to add to the proxy container.
+extraVolumeMounts: []
+#  - name: pebble-ca
+#    mountPath: /pebble-ca
+#    readOnly: true
+
+# -- Init containers to add to the pod.
+initContainers: []

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -33,6 +33,14 @@ proxy:
   # -- Comma-separated CIDR ranges of trusted upstream proxies.
   trustedProxies: ""
 
+wireguard:
+  # -- Enable WireGuard UDP port exposure for P2P connectivity.
+  # Only works with single-account deployments; multiple accounts
+  # will fail to bind the same port.
+  enabled: false
+  # -- Fixed WireGuard port. Set to 0 for random OS-assigned port.
+  port: 51820
+
 acme:
   # -- Enable ACME certificate generation.
   enabled: true

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -25,9 +25,9 @@ allowInsecure: false
 proxy:
   # -- Listen address for the HTTPS reverse proxy.
   address: ":8443"
-  # -- Public URL of the proxy (used for ACME and client access).
+  # -- Public domain of the proxy (e.g., netbird.example.com).
   # Leave empty to auto-derive from the proxy address.
-  url: ""
+  domain: ""
   # -- X-Forwarded-Proto behaviour: auto, http, or https.
   forwardedProto: "auto"
   # -- Comma-separated CIDR ranges of trusted upstream proxies.

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -148,6 +148,14 @@ service:
   port: 443
   # -- ACME HTTP-01 challenge port (only exposed if acme.enabled).
   acmePort: 80
+  # -- IP families for dual-stack support. Dual-stack allows clients with
+  # IPv6 connectivity to reach peers directly without NAT traversal.
+  ipFamilies:
+    - IPv4
+    - IPv6
+  # -- IP family policy: SingleStack, PreferDualStack, or RequireDualStack.
+  # PreferDualStack falls back gracefully on single-stack clusters.
+  ipFamilyPolicy: PreferDualStack
 
   loadBalancer:
     # -- Source ranges allowed to reach the LoadBalancer.

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: netbird-proxy
@@ -215,13 +215,13 @@ service:
     # Local preserves client source IP but may cause imbalanced traffic.
     externalTrafficPolicy: ""
 
-resources:
-  requests:
-    cpu: 100m
-    memory: 64Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
+resources: {}
+#  requests:
+#    cpu: 100m
+#    memory: 64Mi
+#  limits:
+#    cpu: 500m
+#    memory: 256Mi
 
 # -- Host aliases to inject into /etc/hosts.
 hostAliases: []
@@ -244,7 +244,7 @@ affinity: {}
 
 podDisruptionBudget:
   # -- Create a PodDisruptionBudget.
-  enabled: true
+  enabled: false
   # -- Minimum available pods.
   minAvailable: 1
   # -- Maximum unavailable pods (mutually exclusive with minAvailable).
@@ -282,18 +282,18 @@ autoscaling:
 # -- Extra environment variables to add to the proxy container.
 extraEnv: []
 #  - name: SSL_CERT_FILE
-#    value: "/pebble-ca/pebble-ca.pem"
+#    value: "/custom-ca/ca.pem"
 
 # -- Extra volumes to add to the pod.
 extraVolumes: []
-#  - name: pebble-ca
+#  - name: custom-ca
 #    secret:
-#      secretName: pebble-ca
+#      secretName: custom-ca
 
 # -- Extra volume mounts to add to the proxy container.
 extraVolumeMounts: []
-#  - name: pebble-ca
-#    mountPath: /pebble-ca
+#  - name: custom-ca
+#    mountPath: /custom-ca
 #    readOnly: true
 
 # -- Extra ports to expose on the Service and container.

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -37,21 +37,42 @@ proxy:
   # that use PROXY protocol to forward real client IPs.
   proxyProtocol: false
 
-wireguard:
-  # -- Enable WireGuard UDP port exposure for P2P connectivity.
-  # Only works with single-account deployments; multiple accounts
-  # will fail to bind the same port.
+# -- Allow users to choose a specific listen port for TCP/UDP services.
+# When false, ports are auto-assigned by management. When true, users
+# can specify a custom port number via the API or dashboard.
+supportsCustomPorts: true
+
+# -- Require a subdomain label in front of the cluster domain. When true,
+# accounts cannot create services on the bare cluster domain. Enable this
+# on shared proxy deployments to prevent a single account from claiming
+# the cluster domain.
+requireSubdomain: false
+
+# -- Use host networking. Required for TCP/UDP service passthrough in
+# Kubernetes, since dynamically bound ports cannot be declared in the
+# Service manifest. When enabled, the container shares the host's
+# network namespace and all listen ports are directly reachable.
+hostNetwork: false
+
+netbirdPort:
+  # -- Expose the NetBird UDP port for direct peer connectivity.
   enabled: false
-  # -- Fixed WireGuard port. Set to 0 for random OS-assigned port.
+  # -- Fixed port number. Set to 0 for random OS-assigned port.
   port: 51820
 
 acme:
   # -- Enable ACME certificate generation.
   enabled: true
-  # -- HTTP-01 challenge listen address.
+  # -- Challenge type: tls-alpn-01 (default, uses port 443) or http-01 (requires port 80).
+  challengeType: "tls-alpn-01"
+  # -- HTTP-01 challenge listen address (only used when challengeType is http-01).
   address: ":80"
   # -- ACME directory URL.
   directory: "https://acme-v02.api.letsencrypt.org/directory"
+  # -- EAB key ID for providers that require External Account Binding.
+  eabKid: ""
+  # -- EAB HMAC key.
+  eabHmacKey: ""
   # -- Certificate lock method: auto, flock, or k8s-lease.
   certLockMethod: "k8s-lease"
 
@@ -71,6 +92,23 @@ oidc:
   existingOidcSecret: ""
   endpoint: "https://api.netbird.io/oauth2"
   scopes: "openid,profile,email"
+
+geolocation:
+  # -- Enable geolocation lookups for country-based access restrictions.
+  enabled: true
+  # -- Directory for the geolocation database inside the container.
+  dataDir: "/var/lib/netbird/geolocation"
+  volume:
+    # -- Enable persistent storage for the geolocation database.
+    # When false, an emptyDir is used and the database re-downloads on every pod restart.
+    enabled: true
+    # -- Use an existing PVC instead of creating one.
+    existingClaim: ""
+    # -- PVC access mode.
+    accessMode: "ReadWriteOnce"
+    # -- Storage class. Leave empty for the cluster default.
+    storageClass: ""
+    size: "128Mi"
 
 debug:
   # -- Enable the debug HTTP endpoint.
@@ -250,6 +288,12 @@ extraVolumeMounts: []
 #  - name: pebble-ca
 #    mountPath: /pebble-ca
 #    readOnly: true
+
+# -- Extra ports to expose on the Service and container.
+extraPorts: []
+#  - name: tcp-10000
+#    port: 10000
+#    protocol: TCP
 
 # -- Init containers to add to the pod.
 initContainers: []

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -32,10 +32,12 @@ proxy:
   forwardedProto: "auto"
   # -- Comma-separated CIDR ranges of trusted upstream proxies.
   trustedProxies: ""
-  # -- Enable PROXY protocol (v1/v2) on TCP listeners.
-  # Required when behind L4 proxies that support PROXY protocol.
-  # that use PROXY protocol to forward real client IPs.
+  # -- Enable PROXY protocol (v1/v2) on TCP listeners for preserving client IPs.
   proxyProtocol: false
+  # -- Cap per-service backend dial timeout (e.g. "10s"). Empty or "0" means no cap.
+  maxDialTimeout: ""
+  # -- Cap per-service session idle timeout (e.g. "5m"). Empty or "0" means no cap.
+  maxSessionIdleTimeout: ""
 
 # -- Allow users to choose a specific listen port for TCP/UDP services.
 # When false, ports are auto-assigned by management. When true, users
@@ -53,6 +55,9 @@ requireSubdomain: false
 # Service manifest. When enabled, the container shares the host's
 # network namespace and all listen ports are directly reachable.
 hostNetwork: false
+
+# -- Pre-shared key for the tunnel between proxy and peers.
+preSharedKey: ""
 
 netbirdPort:
   # -- Expose the NetBird UDP port for direct peer connectivity.
@@ -75,6 +80,8 @@ acme:
   eabHmacKey: ""
   # -- Certificate lock method: auto, flock, or k8s-lease.
   certLockMethod: "k8s-lease"
+  # -- Directory containing wildcard certificate pairs (<name>.crt/<name>.key).
+  wildcardCertDir: ""
 
 # -- Static TLS certificate configuration (used when acme.enabled=false).
 tls:
@@ -121,8 +128,8 @@ health:
   address: ":8080"
 
 logging:
-  # -- Enable debug-level logging.
-  debug: false
+  # -- Log level: panic, fatal, error, warn, info, debug, trace.
+  level: "info"
 
 # -- Directory where certificates are stored inside the container.
 certDir: "/certs"

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -50,6 +50,16 @@ supportsCustomPorts: true
 # the cluster domain.
 requireSubdomain: false
 
+# -- CrowdSec IP reputation integration.
+crowdsec:
+  # -- CrowdSec LAPI URL. Empty disables CrowdSec.
+  apiUrl: ""
+  # -- Bouncer API key. Empty disables CrowdSec.
+  apiKey: ""
+  # -- Use an existing Secret for the CrowdSec bouncer API key.
+  # The secret must contain a key named "crowdsec-api-key".
+  existingSecret: ""
+
 # -- Use host networking. Required for TCP/UDP service passthrough in
 # Kubernetes, since dynamically bound ports cannot be declared in the
 # Service manifest. When enabled, the container shares the host's

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -38,6 +38,11 @@ proxy:
   maxDialTimeout: ""
   # -- Cap per-service session idle timeout (e.g. "5m"). Empty or "0" means no cap.
   maxSessionIdleTimeout: ""
+  # -- Run Rosenpass (post-quantum key exchange) in permissive mode on the
+  # embedded proxy clients. Required to connect to Rosenpass-enabled peers;
+  # falls back to plain WireGuard for peers without Rosenpass. Set to false
+  # to disable Rosenpass on the proxy.
+  rosenpass: true
 
 # -- Allow users to choose a specific listen port for TCP/UDP services.
 # When false, ports are auto-assigned by management. When true, users

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: netbird-proxy
+  repository: netbirdio/reverse-proxy
   tag: ""
   pullPolicy: IfNotPresent
 
@@ -58,6 +58,9 @@ crowdsec:
   apiKey: ""
   # -- Use an existing Secret for the CrowdSec bouncer API key.
   # The secret must contain a key named "crowdsec-api-key".
+  # Required when the top-level existingSecret is set, since the chart-managed
+  # Secret holding the proxy token is not rendered in that case and cannot
+  # carry crowdsec-api-key.
   existingSecret: ""
 
 # -- Use host networking. Required for TCP/UDP service passthrough in
@@ -155,8 +158,13 @@ certVolume:
   enabled: true
   # -- Mount an existing PVC instead of creating one.
   existingClaim: ""
+  # -- Mount an existing Secret as the certificate volume (e.g. a TLS Secret
+  # produced by cert-manager). Use with acme.enabled=false: ACME mode writes
+  # to this directory, which is read-only when backed by a Secret. The
+  # Secret keys should match tls.certFile and tls.keyFile.
+  existingSecret: ""
   # -- Use a hostPath volume instead of a PVC.
-  # Takes precedence over enabled and existingClaim.
+  # Takes precedence over enabled, existingClaim, and existingSecret.
   hostPath: ""
   # -- PVC access mode. ReadWriteMany is required for multi-replica ACME
   # (HTTP-01 challenges can arrive on any pod). ReadWriteOnce is fine for

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -67,6 +67,23 @@ crowdsec:
   # Secret holding the proxy token is not rendered in that case and cannot
   # carry crowdsec-api-key.
   existingSecret: ""
+  # -- CrowdSec AppSec (WAF) endpoint for HTTP request inspection, e.g.
+  # "http://crowdsec:7422/". Empty disables inspection. This is a separate
+  # endpoint from the LAPI above: the Security Engine must run an appsec
+  # acquisition datasource with at least one appsec-config loaded.
+  # Reuses apiKey, which the AppSec component validates against LAPI, so
+  # setting this without a key is a startup error. Proxies advertise the AppSec
+  # capability only when this is set, which is what gates the per-service
+  # appsec_mode in the dashboard.
+  appsecUrl: ""
+  # -- Timeout for a single AppSec inspection call, e.g. "200ms". Empty uses
+  # 200ms, the budget CrowdSec's remediation component spec assumes. Inspection
+  # is synchronous, so this bounds the latency added to every request.
+  appsecTimeout: ""
+  # -- Cap on the request body mirrored to AppSec, in bytes. Empty uses 65536.
+  # Bodies over the cap are inspected on headers and URI only, never on a
+  # truncated prefix. Set to -1 to never forward bodies.
+  appsecMaxBodyBytes: ""
 
 # -- Use host networking. Required for TCP/UDP service passthrough in
 # Kubernetes, since dynamically bound ports cannot be declared in the


### PR DESCRIPTION
## Summary

Adds a Helm chart for deploying the NetBird reverse proxy.

## Kubernetes Resources

| Resource | Condition | Description |
|---|---|---|
| **Deployment** | Always | Proxy deployment with health probes, configurable cert and data volumes |
| **Service** | Always | Dual-stack (IPv4/IPv6) support, conditional ACME HTTP, NetBird UDP, and extra ports |
| **ServiceAccount** | `serviceAccount.create` | With configurable token automount (required for k8s-lease cert locking) |
| **Secret** | `proxyToken` set (no `existingSecret`) | Proxy token and optional OIDC client secret |
| **PersistentVolumeClaim** | `certVolume.enabled` or `geolocation.volume.enabled` | Shared certificate storage and geolocation database |
| **Role** | `rbac.create` | Grants Kubernetes lease permissions for ACME certificate locking |
| **RoleBinding** | Same as Role | Binds the lease Role to the ServiceAccount |
| **HorizontalPodAutoscaler** | `autoscaling.enabled` | CPU and memory based autoscaling |
| **PodDisruptionBudget** | `podDisruptionBudget.enabled` | Configurable `minAvailable` or `maxUnavailable` |
| **NetworkPolicy** | `networkPolicy.enabled` | Restricts ingress to proxy ports with support for additional custom rules |
| **ServiceMonitor** | `serviceMonitor.enabled` | Prometheus scraping on the health port |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a complete Helm chart for deploying **netbird-proxy** on Kubernetes (Deployment, Service, ServiceAccount).
  * Enabled optional HPA, NetworkPolicy, PodDisruptionBudget, and Prometheus ServiceMonitor.
  * Added configurable support for ACME certificates, OIDC, geolocation storage, CrowdSec, proxy protocol, and extra/custom ports and environment options.
* **Documentation**
  * Added post-deployment access instructions and configuration notes for ACME and proxy protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->