### PR TITLE
Add appProtocol field to Services

### DIFF
--- a/charts/netbird/templates/dashboard-service.yaml
+++ b/charts/netbird/templates/dashboard-service.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.dashboard.service.appProtocol }}
+      appProtocol: {{ .Values.dashboard.service.appProtocol }}
+      {{- end }}
   selector:
     {{- include "netbird.dashboard.selectorLabels" . | nindent 4 }}
   {{- with .Values.dashboard.service.externalIPs }}

--- a/charts/netbird/templates/management-service-grpc.yaml
+++ b/charts/netbird/templates/management-service-grpc.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: {{ .Values.management.serviceGrpc.name }}
       protocol: TCP
       name: {{ .Values.management.serviceGrpc.name }}
+      {{- if .Values.management.serviceGrpc.appProtocol }}
+      appProtocol: {{ .Values.management.serviceGrpc.appProtocol }}
+      {{- end }}
   selector:
     {{- include "netbird.management.selectorLabels" . | nindent 4 }}
   {{- with .Values.management.serviceGrpc.externalIPs }}

--- a/charts/netbird/templates/management-service.yaml
+++ b/charts/netbird/templates/management-service.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: {{ .Values.management.service.name }}
       protocol: TCP
       name: {{ .Values.management.service.name }}
+      {{- if .Values.management.service.appProtocol }}
+      appProtocol: {{ .Values.management.service.appProtocol }}
+      {{- end }}
     {{- if .Values.management.metrics.enabled }}
     - port: {{ .Values.management.metrics.port }}
       targetPort: metrics

--- a/charts/netbird/templates/relay-service.yaml
+++ b/charts/netbird/templates/relay-service.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: {{ .Values.relay.service.name }}
       protocol: TCP
       name: {{ .Values.relay.service.name }}
+      {{- if .Values.relay.service.appProtocol }}
+      appProtocol: {{ .Values.relay.service.appProtocol }}
+      {{- end }}
     {{- if .Values.relay.metrics.enabled }}
     - port: {{ .Values.relay.metrics.port}}
       targetPort: metrics

--- a/charts/netbird/templates/signal-service.yaml
+++ b/charts/netbird/templates/signal-service.yaml
@@ -17,6 +17,9 @@ spec:
       targetPort: {{ .Values.signal.service.name }}
       protocol: TCP
       name: {{ .Values.signal.service.name }}
+      {{- if .Values.signal.service.appProtocol }}
+      appProtocol: {{ .Values.signal.service.appProtocol }}
+      {{- end }}
     {{- if .Values.signal.metrics.enabled }}
     - port: {{ .Values.signal.metrics.port }}
       targetPort: metrics

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -138,6 +138,10 @@ management:
     ##
     name: http
 
+    ## @param management.service.appProtocol AppProtocol for the management service port.
+    ##
+    appProtocol: kubernetes.io/h2c
+
     ## @param management.service.externalIPs External IPs for the management service.
     ##
     externalIPs: []
@@ -162,6 +166,10 @@ management:
     ## @param management.serviceGrpc.name Name for the management GRPC service port.
     ##
     name: grpc
+
+    ## @param management.serviceGrpc.appProtocol AppProtocol for the management GRPC service port.
+    ##
+    appProtocol: kubernetes.io/h2c
 
     ## @param management.serviceGrpc.externalIPs External IPs for the management GRPC service.
     ##
@@ -397,6 +405,10 @@ signal:
     ##
     name: grpc
 
+    ## @param signal.service.appProtocol AppProtocol for the signal service port.
+    ##
+    appProtocol: kubernetes.io/h2c
+
     ## @param signal.service.externalIPs External IPs for the signal service.
     ##
     externalIPs: []
@@ -590,6 +602,10 @@ relay:
     ##
     name: http
 
+    ## @param relay.service.appProtocol AppProtocol for the relay service port.
+    ##
+    appProtocol: ""
+
     ## @param relay.service.externalIPs External IPs for the relay service.
     ##
     externalIPs: []
@@ -754,6 +770,10 @@ dashboard:
     ## @param dashboard.service.name Name for the dashboard service port.
     ##
     name: http
+
+    ## @param dashboard.service.appProtocol AppProtocol for the dashboard service port.
+    ##
+    appProtocol: ""
 
     ## @param dashboard.service.externalIPs External IPs for the dashboard service.
     ##


### PR DESCRIPTION
This field is required to be kubernetes.io/h2c for gRPC when using the Cilium Gateway API implementation

See https://docs.cilium.io/en/latest/network/servicemesh/gateway-api/grpc/ for more information
