### PR TITLE
feat(netbird-proxy): expose deployment rollout settings

### DIFF
--- a/charts/netbird-proxy/templates/deployment.yaml
+++ b/charts/netbird-proxy/templates/deployment.yaml
@@ -8,6 +8,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "netbird-proxy.selectorLabels" . | nindent 6 }}

--- a/charts/netbird-proxy/values.yaml
+++ b/charts/netbird-proxy/values.yaml
@@ -1,5 +1,12 @@
 replicaCount: 1
 
+# -- Number of old ReplicaSets to retain.
+revisionHistoryLimit: 10
+
+# -- Deployment rollout strategy.
+strategy:
+  type: RollingUpdate
+
 image:
   repository: netbirdio/reverse-proxy
   tag: ""


### PR DESCRIPTION
### Summary

- expose Deployment rollout strategy through Helm values
- expose ReplicaSet revision history limit
- support `Recreate` rollouts for single-replica RWO storage

### Validation

- `helm lint charts/netbird-proxy`
- rendered with `strategy.type=Recreate` and `revisionHistoryLimit=0`